### PR TITLE
Remove >= from cabal-version

### DIFF
--- a/js-chart.cabal
+++ b/js-chart.cabal
@@ -1,4 +1,4 @@
-cabal-version:      >=1.18
+cabal-version:      1.18
 build-type:         Simple
 name:               js-chart
 version:            2.9.4.1


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: js-chart.cabal:1:27: Packages with 'cabal-version: 1.12' or later
should specify a specific version of the Cabal spec of the form
'cabal-version: x.y'. Use 'cabal-version: 1.18'.
```